### PR TITLE
Add working WiFi support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@ This is the base Nerves System configuration for the
 
 | Feature        | Description                                                 |
 | -------------- | ----------------------------------------------------------- |
-| CPU            | 1.8 GHz quad-core Cortex-A53 (64-bit)                        |
+| CPU            | 1.8 GHz quad-core Cortex-A53 (64-bit)                       |
 | NPU            | AI/ML Neural Processing Unit, up to 2.3 TOPS                |
 | MCU            | ARM Cortex-M7, 800Mhz                                       |
 | Storage        | eMMC                                                        |
-| Linux kernel   | 6.1                                                         |
+| Linux kernel   | 6.6                                                         |
 | IEx terminal   | UART `ttymxc1`                                              |
 | GPIO, I2C, SPI | Yes - [Elixir Circuits](https://github.com/elixir-circuits) |
 | Display        | Yes                                                         |
-| Ethernet       | Yes                                                         |
+| Ethernet       | Yes - ETH2 port is recognized as `eth0`                     |
 | WiFi           | Yes                                                         |
 | Bluetooth      | Yes                                                         |
 | RTC            | Yes                                                         |
@@ -25,9 +25,23 @@ This is the base Nerves System configuration for the
 [Image credit](#compulab): This image is from
 [compulab.com](https://www.compulab.com/products/iot-gateways/iot-gate-imx8plus-industrial-arm-iot-gateway).
 
-### Getting started
+## Getting started
 
 The IOT-GATE-IMX8PLUS gateway expects the bootloader to be located on hardware BOOT partition 1. When flashing firmware, ensure that both the bootloader and a complete disk image, generated using the fwup CLI tool, are provided.
+
+### Wi-Fi
+
+The IOT-GATE-IMX8PLUS has support for an installable Intel Wi-Fi 6 AX210 / Bluetooth module.
+
+Wi-Fi can be enabled by loading the kernel module.
+
+```elixir
+iex> cmd "modprobe iwlwifi"
+```
+
+_Please note: AP mode has not been tested._
+
+### Building firmware
 
 #### Prerequisites
 

--- a/package/compulab/compulab.hash
+++ b/package/compulab/compulab.hash
@@ -1,1 +1,1 @@
-sha256  df733e4ff2cec0d07acfb174aab2f1b3daf7e5c16e4a0d1e82dd6de8eea9c347  14f548ef600.tar.gz
+sha256  a0d5f75d9f1e59bcd0e853b706c5bcfb1cd740870202236ef610b74c48ef1751  b43fe71dba3.tar.gz

--- a/package/compulab/compulab.mk
+++ b/package/compulab/compulab.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-COMPULAB_VERSION = 14f548ef600
+COMPULAB_VERSION = b43fe71dba3
 COMPULAB_SITE = https://github.com/compulab-yokneam/buildroot/archive
 COMPULAB_SOURCE = $(COMPULAB_VERSION).tar.gz
 

--- a/post-build.sh
+++ b/post-build.sh
@@ -2,6 +2,12 @@
 
 set -ex
 
+# Make sure we copy over the expected iwlwifi firmware files.
+# The Buildroot linux-firmware package is only copying over iwlwifi-so-a0-gf-a0*.{ucode,pnvm},
+# but the `iwlwifi` driver is looking for iwlwifi-ty-a0-gf-a0*.{ucode,pnvm} files.
+cp $BUILD_DIR/linux-firmware-20250211/iwlwifi-ty-a0-gf-a0*.ucode $TARGET_DIR/lib/firmware
+cp $BUILD_DIR/linux-firmware-20250211/iwlwifi-ty-a0-gf-a0.pnvm $TARGET_DIR/lib/firmware
+
 # Create the fwup ops script for handling MicroSD/eMMC operations at runtime
 mkdir -p $TARGET_DIR/usr/share/fwup
 


### PR DESCRIPTION
During my testing of my IMX8 Plus, I noticed that WiFi wasn't working when using `cmd "modprobe iwlwifi"`, and instead spews errors into `dmesg`

From my sleuthing, the firmware files expected by the module were not being installed, and after establishing that they were available to be copied from the `linux-firmware-20250211` package, well, thats all it took.

I also updated `compulab` package to match the kernel version used, and added some super basic docs to the `README.d`