### PR TITLE
`Nerves.Runtime` already takes care of starting `rngd` very early on

### DIFF
--- a/rootfs_overlay/etc/erlinit.config
+++ b/rootfs_overlay/etc/erlinit.config
@@ -14,13 +14,6 @@
 # Use nbtty to improve terminal handling on serial ports. It's a noop on HDMI.
 -s "/usr/bin/nbtty"
 
-# There's a call to getrandom(2) when loading the crypto NIF that's before
-# nerves_runtime can start rngd. This syscall can block the BEAM indefinitely
-# if there's not enough entropy in the kernel. We have not observed blocking on
-# this platform. However, we don't know that getrandom(2) will always have
-# enough entropy, so start rngd here to be safe.
---pre-run-exec /usr/sbin/rngd
-
 # Specify the user and group IDs for the Erlang VM
 #--uid 100
 #--gid 200


### PR DESCRIPTION
Also see https://github.com/nerves-project/nerves_runtime/pull/391