### PR TITLE
Update firmware validation logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,34 @@ The IOT-GATE-IMX8PLUS can be ordered with an Intel Wi-Fi 6 AX210 / Bluetooth mod
 iex> cmd "modprobe iwlwifi"
 ```
 
+### Firmware validation
+
+Firmware is validated by default using the `nerves_fw_autovalidate` U-Boot variable.
+
+If you want to enable explicit firmware validation (highly recommended), you will need to set the `nerves_fw_autovalidate` variable to `1` in the U-Boot environment, and implement some custom logic to validate the firmware.
+
+e.g, you can add the following code to your `Application.start/2` function:
+
+```elixir
+# Disable firmware auto validation
+if Nerves.Runtime.KV.get("nerves_fw_autovalidate") == "1" do
+  Nerves.Runtime.KV.put("nerves_fw_autovalidate", "0")
+end
+```
+
+And then later in your application's code, after you have determined that the firmware is valid to continue using:
+
+```elixir
+# Validate firmware
+Nerves.Runtime.validate_firmware()
+```
+
+You can read more about firmware validation in the Nerves Runtime documentation:
+
+- [Assisted firmware validation and automatic revert](https://hexdocs.pm/nerves_runtime/readme.html#assisted-firmware-validation-and-automatic-revert)
+- [U-Boot assisted automatic revert](https://hexdocs.pm/nerves_runtime/readme.html#u-boot-assisted-automatic-revert)
+- [Nerves.Runtime.html#validate_firmware/1](https://hexdocs.pm/nerves_runtime/Nerves.Runtime.html#validate_firmware/1)
+
 ### Building firmware
 
 #### Prerequisites

--- a/fwup-ops.conf
+++ b/fwup-ops.conf
@@ -86,7 +86,7 @@ task revert.a {
 
         # Switch over
         uboot_setenv(uboot-env, "nerves_fw_active", "a")
-        uboot_setenv(uboot-env, "nerves_fw_validated", "1")
+        uboot_setenv(uboot-env, "a.nerves_fw_validated", "1")
     }
 }
 
@@ -103,7 +103,7 @@ task revert.b {
 
         # Switch over
         uboot_setenv(uboot-env, "nerves_fw_active", "b")
-        uboot_setenv(uboot-env, "nerves_fw_validated", "1")
+        uboot_setenv(uboot-env, "b.nerves_fw_validated", "1")
     }
 }
 
@@ -162,11 +162,26 @@ task status.fail {
 ##
 # validate
 ##
-task validate {
+task validate.a {
+    require-uboot-variable(uboot-env, "nerves_fw_active", "a")
+
     on-init {
-        info("Validate")
-        uboot_setenv(uboot-env, "nerves_fw_validated", "1")
+        info("Validate A")
+        uboot_setenv(uboot-env, "a.nerves_fw_validated", "1")
         uboot_setenv(uboot-env, "upgrade_available", "0")
         uboot_setenv(uboot-env, "bootcount", "1")
     }
+}
+task validate.b {
+    require-uboot-variable(uboot-env, "nerves_fw_active", "b")
+
+    on-init {
+        info("Validate B")
+        uboot_setenv(uboot-env, "b.nerves_fw_validated", "1")
+        uboot_setenv(uboot-env, "upgrade_available", "0")
+        uboot_setenv(uboot-env, "bootcount", "1")
+    }
+}
+task validate.fail {
+    on-init { error("Failed") }
 }

--- a/fwup.conf
+++ b/fwup.conf
@@ -86,7 +86,7 @@ task upgrade.a {
 
     # Require that the running version of firmware has been validated.
     # If it has not, then failing back is not guaranteed to work.
-    require-uboot-variable(uboot-env, "nerves_fw_validated", "1")
+    require-uboot-variable(uboot-env, "b.nerves_fw_validated", "1")
 
     # Verify the expected platform/architecture
     require-uboot-variable(uboot-env, "b.nerves_fw_platform", "${NERVES_FW_PLATFORM}")
@@ -131,8 +131,9 @@ task upgrade.a {
         # Reset the validation status and boot to A
         # next time.
         uboot_setenv(uboot-env, "nerves_fw_active", "a")
-        uboot_setenv(uboot-env, "nerves_fw_validated", "0")
+        uboot_setenv(uboot-env, "a.nerves_fw_validated", "0")
         uboot_setenv(uboot-env, "nerves_fw_booted", "0")
+        uboot_setenv(uboot-env, "upgrade_available", "1")
     }
 
     on-error {
@@ -141,7 +142,7 @@ task upgrade.a {
 
 task upgrade.b {
     require-uboot-variable(uboot-env, "nerves_fw_active", "a")
-    require-uboot-variable(uboot-env, "nerves_fw_validated", "1")
+    require-uboot-variable(uboot-env, "a.nerves_fw_validated", "1")
 
     # Verify the expected platform/architecture
     require-uboot-variable(uboot-env, "a.nerves_fw_platform", "${NERVES_FW_PLATFORM}")
@@ -183,16 +184,25 @@ task upgrade.b {
 
         # Reset the validation status and boot to B next time.
         uboot_setenv(uboot-env, "nerves_fw_active", "b")
-        uboot_setenv(uboot-env, "nerves_fw_validated", "0")
+        uboot_setenv(uboot-env, "b.nerves_fw_validated", "0")
         uboot_setenv(uboot-env, "nerves_fw_booted", "0")
+        uboot_setenv(uboot-env, "upgrade_available", "1")
     }
 
     on-error {
     }
 }
 
-task upgrade.unvalidated {
-    require-uboot-variable(uboot-env, "nerves_fw_validated", "0")
+task upgrade.unvalidated.a {
+    require-uboot-variable(uboot-env, "a.nerves_fw_validated", "0")
+
+    on-init {
+        error("Please validate the running firmware before upgrading it again.")
+    }
+}
+
+task upgrade.unvalidated.b {
+    require-uboot-variable(uboot-env, "b.nerves_fw_validated", "0")
 
     on-init {
         error("Please validate the running firmware before upgrading it again.")

--- a/uboot/uboot.env
+++ b/uboot/uboot.env
@@ -9,7 +9,7 @@
 nerves_fw_active=a
 
 # nerves_fw_autovalidate controls whether updates are considered valid once
-# applied. If set to 0, the user needs to set nerves_fw_validated to 1 in their
+# applied. If set to 0, the user needs to explicitly validate the firmware in their
 # application. If they don't set it before a reboot, then the previous software
 # is run. If 1, then no further action needs to be taken.
 nerves_fw_autovalidate=1
@@ -17,7 +17,7 @@ nerves_fw_autovalidate=1
 # nerves_fw_validated is 1 if the current boot selection is accepted It is set
 # to 1 here, since this environment is written in the factory, so it is
 # implicitly valid.
-nerves_fw_validated=1
+a.nerves_fw_validated=1
 
 # nerves_fw_booted is 0 for the first boot and 1 for all reboots after that.
 # NOTE: Keep this '0' so that all new boards run a 'saveenv' to exercise the
@@ -34,22 +34,33 @@ nerves_revert=\
     if test ${nerves_fw_active} = "a"; then\
         echo "Reverting to partition B";\
         setenv nerves_fw_active "b";\
+        setenv b.nerves_fw_validated 1;\
     else\
         echo "Reverting to partition A";\
         setenv nerves_fw_active "a";\
+        setenv a.nerves_fw_validated 1;\
+    fi
+
+nerves_auto_validate=\
+    if test ${nerves_fw_active} = "a"; then\
+        echo "Auto validating partition A";\
+        setenv a.nerves_fw_validated 1;\
+    else\
+        echo "Auto validating partition B";\
+        setenv b.nerves_fw_validated 1;\
     fi
 
 nerves_init=\
     if test ${nerves_fw_booted} = 1; then\
-        if test ${nerves_fw_validated} = 0; then\
+        if test ${upgrade_available} = 1; then\
             run nerves_revert;\
-            setenv nerves_fw_validated 1;\
+            setenv upgrade_available 0;\
             saveenv;\
         fi;\
     else\
         setenv nerves_fw_booted 1;\
         if test ${nerves_fw_autovalidate} = 1; then\
-            setenv nerves_fw_validated 1;\
+            run nerves_auto_validate;\
         fi;\
         saveenv;\
     fi;\


### PR DESCRIPTION
This PR has three core changes:

- Use `[slot].nerves_fw_validated` for tracking the validation status of firmware in the various slots
- Tweak how/where `upgrade_available` is updated (when firmware is upgraded)
- Document how to disable automatic firmware validation

These changes have been tested and work perfectly, including how Link checks if [firmware has been reverted](firmware_auto_revert_detected).